### PR TITLE
Initial auth work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ npm-debug.log
 # Docker
 Dockerfile
 docker-compose.yml
+
+# Webstorm
+.idea/*

--- a/auth/login.js
+++ b/auth/login.js
@@ -1,0 +1,18 @@
+module.exports = function(passport) {
+    var LocalStrategy = require('passport-local').Strategy;
+
+    passport.use(new LocalStrategy(
+        function (username, password, done) {
+            console.log('username: ' + username + ', password: ' + password);
+            return done(null, {username: username, id: 1});
+        }
+    ));
+
+    passport.serializeUser(function (user, done) {
+        done(null, user.id);
+    });
+
+    passport.deserializeUser(function (id, done) {
+        done(null, {id: id});
+    });
+};

--- a/auth/login.js
+++ b/auth/login.js
@@ -1,18 +1,27 @@
-module.exports = function(passport) {
+module.exports = {
+  initialize: function(passport) {
     var LocalStrategy = require('passport-local').Strategy;
 
     passport.use(new LocalStrategy(
-        function (username, password, done) {
-            console.log('username: ' + username + ', password: ' + password);
-            return done(null, {username: username, id: 1});
-        }
+      function (username, password, done) {
+        console.log('username: ' + username + ', password: ' + password);
+        return done(null, {username: username, id: 1});
+      }
     ));
 
     passport.serializeUser(function (user, done) {
-        done(null, user.id);
+      done(null, user.id);
     });
 
     passport.deserializeUser(function (id, done) {
-        done(null, {id: id});
+      done(null, { id: id, username: "test-user" });
     });
+  },
+  ensureAuthenticated: function(req, res, next) {
+    if (!req.isAuthenticated()) {
+      res.status(401).json({ error: "not unauthenticated" });
+    } else { 
+      next();
+    }
+  }
 };

--- a/index.js
+++ b/index.js
@@ -4,30 +4,34 @@ var app = express();
 var pg = require('pg');
 var students = require(__dirname + '/views/pages/students.js');
 var passport = require('passport')
-	, LocalStrategy = require('passport-local').Strategy;
+  , LocalStrategy = require('passport-local').Strategy;
+var bodyParser = require('body-parser');
 	
 passport.use(new LocalStrategy(
   function(username, password, done) {
-    User.findOne({ username: username }, function(err, user) {
-      if (err) { return done(err); }
-      if (!user) {
-        return done(null, false, { message: 'Incorrect username.' });
-      }
-      if (!user.validPassword(password)) {
-        return done(null, false, { message: 'Incorrect password.' });
-      }
-      return done(null, user);
-    });
+    console.log('username: ' + username + ', password: ' + password);
+
+    return done(null, { username: username });
+
+    console.log('outside findOne');
   }
 ));
 
-app.post('/login',
-  passport.authenticate('local', { successRedirect: '/',
-                                   failureRedirect: '/login',
-                                   failureFlash: false })
-);
-	
-	
+app.use(passport.initialize());
+app.use(bodyParser.urlencoded({
+  extended: true
+}));
+app.use(bodyParser.json());
+
+app.post('/login', passport.authenticate('local', { successRedirect: '/success', failureRedirect: '/failure' }), function(req, res) {
+  res.json({ success: true });
+});
+
+app.post('/auth', function(req, res){
+  console.log("body parsing", req.body);
+  //should be something like: {username: YOURUSERNAME, password: YOURPASSWORD}
+  res.json({ done: true });
+});
 
 app.set('port', (process.env.PORT || 5000));
 
@@ -65,13 +69,4 @@ app.get('/db', function (request, response) {
     });
   });
 });
-
-
-
-//Auth temporary work
-
-
-
-
-
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,34 @@
+
 var express = require('express');
 var app = express();
 var pg = require('pg');
 var students = require(__dirname + '/views/pages/students.js');
+var passport = require('passport')
+	, LocalStrategy = require('passport-local').Strategy;
+	
+passport.use(new LocalStrategy(
+  function(username, password, done) {
+    User.findOne({ username: username }, function(err, user) {
+      if (err) { return done(err); }
+      if (!user) {
+        return done(null, false, { message: 'Incorrect username.' });
+      }
+      if (!user.validPassword(password)) {
+        return done(null, false, { message: 'Incorrect password.' });
+      }
+      return done(null, user);
+    });
+  }
+));
+
+app.post('/login',
+  passport.authenticate('local', { successRedirect: '/',
+                                   failureRedirect: '/login',
+                                   failureFlash: false })
+);
+	
+	
+
 app.set('port', (process.env.PORT || 5000));
 
 app.use(express.static(__dirname + '/public'));
@@ -17,6 +44,7 @@ app.get('/', function(request, response) {
 app.get('/student', function(request, response) {
   response.render('pages/student-info', {studentsinfo: students});
 });
+
 
 app.listen(app.get('port'), function() {
   console.log('Node app is running on port', app.get('port'));
@@ -37,3 +65,13 @@ app.get('/db', function (request, response) {
     });
   });
 });
+
+
+
+//Auth temporary work
+
+
+
+
+
+

--- a/index.js
+++ b/index.js
@@ -3,19 +3,8 @@ var express = require('express');
 var app = express();
 var pg = require('pg');
 var students = require(__dirname + '/views/pages/students.js');
-var passport = require('passport')
-  , LocalStrategy = require('passport-local').Strategy;
+var passport = require('passport');
 var bodyParser = require('body-parser');
-	
-passport.use(new LocalStrategy(
-  function(username, password, done) {
-    console.log('username: ' + username + ', password: ' + password);
-
-    return done(null, { username: username });
-
-    console.log('outside findOne');
-  }
-));
 
 app.use(passport.initialize());
 app.use(bodyParser.urlencoded({
@@ -23,6 +12,7 @@ app.use(bodyParser.urlencoded({
 }));
 app.use(bodyParser.json());
 
+require('./auth/login')(passport);
 app.post('/login', passport.authenticate('local', { successRedirect: '/success', failureRedirect: '/failure' }), function(req, res) {
   res.json({ success: true });
 });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "node index.js"
   },
   "dependencies": {
+    "body-parser": "^1.18.2",
     "cool-ascii-faces": "1.3.3",
     "ejs": "2.4.1",
     "express": "4.13.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cool-ascii-faces": "1.3.3",
     "ejs": "2.4.1",
     "express": "4.13.3",
+    "express-session": "^1.15.6",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
     "pg": "4.5.6"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "cool-ascii-faces": "1.3.3",
     "ejs": "2.4.1",
     "express": "4.13.3",
+    "passport": "^0.4.0",
+    "passport-local": "^1.0.0",
     "pg": "4.5.6"
   },
   "repository": {


### PR DESCRIPTION
This is the initial implementation for authenticating routes to this node app. It uses passport and passport's 'local' strategy, which basically takes in a username/password and then sets a cookie. The only route with this configured is /login, which will currently just redirect /success or /failure.  

Each route that requires authentication can use the ensureAuthentication middleware, which will simply check for the cookie, and return a 401 if it's not valid. In your own route handlers, there will be a req.user object available. Permission model coming soon. See /test-auth for an example. 

Right now, this will succesfully authenticate any username/password sent to /login. 